### PR TITLE
NYSDOT fixes

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -196,9 +196,12 @@ function processTile (tx, ty, zoom, patterns, stops) {
     const coordsPx = ptn.coordsPx[zoom]
     let isect = false
     for (let c = 0; c < coordsPx.length - 1; c++) {
-      if (linegeom.isectRectangleLine(
+      if (
+        linegeom.isectRectangleLine(
           pixelOffsets[0], pixelOffsets[1], pixelOffsets[0] + 256, pixelOffsets[1] + 256,
-          coordsPx[c][0], coordsPx[c][1], coordsPx[c + 1][0], coordsPx[c + 1][1])) {
+          coordsPx[c][0], coordsPx[c][1], coordsPx[c + 1][0], coordsPx[c + 1][1]
+        )
+      ) {
         isect = true
         break
       }
@@ -328,6 +331,9 @@ function renderTile (tx, ty, zoom, patterns, stops) {
     const placedBBoxes = []
     for (let ptn of patterns) {
       const routeShortName = ptn.route_short_name
+      // Skip label if there is no short name
+      // TODO: add logic to handle long name
+      if (!routeShortName) continue
       // check if already placed label for this route in this tile
       if (placedNames.indexOf(routeShortName) !== -1) continue
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Transit map tiler",
   "main": "generate.js",
   "scripts": {
-    "generate": "node lib/generate.js",
+    "generate": "node -max-old-space-size=8192 lib/generate.js",
     "blanks": "node lib/blanks.js",
     "demo": "budo demo.js",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- Skip labeling routes that do not have short names
- Increase memory allocation for generating tiles